### PR TITLE
dplyr no longer marks its errors with class "dplyr_error"

### DIFF
--- a/tests/testthat/test-filter_scoped.R
+++ b/tests/testthat/test-filter_scoped.R
@@ -23,9 +23,7 @@ test_that("filter fails with incorrect statement", {
   expect_error(filter_scoped(iris,
     "Spec == 'setosa'",
     scope_at = NULL
-  ),
-  class = "dplyr_error"
-  )
+  ))
 })
 
 


### PR DESCRIPTION
We are about to release dplyr 1.0.8 and this currently makes this package fail on: 

````
── Test failures ─────────────────────────────────────────────────────────────────────────────── testthat ────

> library(testthat)
> library(datacleanr)
> 
> test_check("datacleanr")
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure (test-filter_scoped.R:23:3): filter fails with incorrect statement ──
`filter_scoped(iris, "Spec == 'setosa'", scope_at = NULL)` threw an error with unexpected class.
Expected class: dplyr_error
Actual class:   rlang_error/error/condition
Message:        Problem while computing `..1 = eval(statement)`.
Backtrace:
     ▆
  1. ├─testthat::expect_error(...) at test-filter_scoped.R:23:2
  2. │ └─testthat:::quasi_capture(...)
  3. │   ├─testthat .capture(...)
  4. │   │ └─base::withCallingHandlers(...)
  5. │   └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
  6. ├─datacleanr:::filter_scoped(iris, "Spec == 'setosa'", scope_at = NULL)
  7. │ ├─dplyr::group_by(...)
  8. │ ├─dplyr::filter(dplyr::ungroup(dframe), eval(statement), na.rm = TRUE)
  9. │ └─dplyr:::filter.data.frame(...)
 10. │   └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
 11. │     └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
 12. │       ├─base::withCallingHandlers(...)
 13. │       └─mask$eval_all_filter(dots, env_filter)
 14. └─base::eval(statement)
 15.   └─base::eval(statement)

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 46 ]
Error: Test failures
Execution halted

1 error x | 0 warnings ✓ | 1 note x
````

because dplyr will no longer mark errors with the `dplyr_error` class. 

Please consider releasing after incorporating this change, which should be fine with both released and future version of `dplyr`. 